### PR TITLE
Update fake documentation to use novel signals

### DIFF
--- a/mcp_use/__init__.py
+++ b/mcp_use/__init__.py
@@ -5,7 +5,7 @@ This library provides a unified interface for connecting different LLMs
 to MCP tools through existing LangChain adapters.
 """
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 # Import logging FIRST to ensure it's configured before other modules
 # This MUST happen before importing observability to ensure loggers are configured
@@ -19,7 +19,10 @@ from .config import load_config_file
 from .connectors import BaseConnector, HttpConnector, StdioConnector, WebSocketConnector
 from .session import MCPSession
 
-__version__ = version("mcp-use")
+try:
+    __version__ = version("mcp-use")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"
 
 __all__ = [
     "MCPAgent",

--- a/mcp_use/auto_update/__init__.py
+++ b/mcp_use/auto_update/__init__.py
@@ -1,0 +1,23 @@
+"""Auto-update toolkit for adapting MCP-Use to new LLM formats."""
+
+from .analyzer import ChangeAnalysis, ChangeSignal, DocumentationAnalyzer
+from .generator import AdapterGenerator, CodeGenerationPlan, GenerationArtifact
+from .intelligence import DocumentationIntelligence, IntelligenceReport, IntelligenceSignal
+from .scraper import DocumentationScraper, DocumentationSnapshot
+from .tester import AutoUpdateTestSuite, TestResult
+
+__all__ = [
+    "AdapterGenerator",
+    "AutoUpdateTestSuite",
+    "ChangeAnalysis",
+    "ChangeSignal",
+    "CodeGenerationPlan",
+    "DocumentationIntelligence",
+    "DocumentationAnalyzer",
+    "DocumentationScraper",
+    "DocumentationSnapshot",
+    "IntelligenceReport",
+    "IntelligenceSignal",
+    "GenerationArtifact",
+    "TestResult",
+]

--- a/mcp_use/auto_update/analyzer.py
+++ b/mcp_use/auto_update/analyzer.py
@@ -1,0 +1,59 @@
+"""Analyze scraped documentation with LLM-backed intelligence."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .intelligence import DocumentationIntelligence, IntelligenceReport, IntelligenceSignal
+from .scraper import DocumentationSnapshot
+
+
+@dataclass(slots=True)
+class ChangeSignal:
+    """A structured signal extracted from the intelligence report."""
+
+    keyword: str
+    description: str
+    severity: str = "info"
+
+
+@dataclass(slots=True)
+class ChangeAnalysis:
+    """Structured result describing the impact of a documentation snapshot."""
+
+    model: str
+    signals: list[ChangeSignal] = field(default_factory=list)
+    json_schemas: list[dict[str, Any]] = field(default_factory=list)
+    recommended_updates: list[str] = field(default_factory=list)
+    insights_summary: str | None = None
+
+    def add_signal(self, keyword: str, description: str, severity: str = "info") -> None:
+        self.signals.append(ChangeSignal(keyword=keyword, description=description, severity=severity))
+
+    def add_recommendation(self, recommendation: str) -> None:
+        self.recommended_updates.append(recommendation)
+
+
+class DocumentationAnalyzer:
+    """Derive actionable information from documentation snapshots via an LLM."""
+
+    def __init__(self, intelligence: DocumentationIntelligence) -> None:
+        self._intelligence = intelligence
+
+    def analyze(self, snapshot: DocumentationSnapshot) -> ChangeAnalysis:
+        report = self._intelligence.analyze(snapshot)
+        analysis = ChangeAnalysis(model=snapshot.model, insights_summary=report.summary)
+        self._apply_report(report, analysis)
+        return analysis
+
+    def _apply_report(self, report: IntelligenceReport, analysis: ChangeAnalysis) -> None:
+        for signal in report.signals:
+            self._add_signal(signal, analysis)
+        analysis.json_schemas.extend(report.json_schemas)
+        for recommendation in report.recommendations:
+            analysis.add_recommendation(recommendation)
+
+    def _add_signal(self, signal: IntelligenceSignal, analysis: ChangeAnalysis) -> None:
+        keyword = signal.keyword or "llm_signal"
+        description = signal.description or signal.keyword or "LLM reported change"
+        severity = signal.severity or "info"
+        analysis.add_signal(keyword=keyword, description=description, severity=severity)

--- a/mcp_use/auto_update/generator.py
+++ b/mcp_use/auto_update/generator.py
@@ -1,0 +1,83 @@
+"""Plan and generate code patches for new tool formats."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from .analyzer import ChangeAnalysis
+
+
+@dataclass(slots=True)
+class GenerationArtifact:
+    """Represents a code artifact produced by the generator."""
+
+    filename: str
+    content: str
+
+
+@dataclass(slots=True)
+class CodeGenerationPlan:
+    """High-level instructions for updating MCP-Use."""
+
+    model: str
+    summary: str
+    tasks: list[str] = field(default_factory=list)
+    artifacts: list[GenerationArtifact] = field(default_factory=list)
+
+    def add_task(self, task: str) -> None:
+        self.tasks.append(task)
+
+    def add_artifact(self, filename: str, content: str) -> None:
+        self.artifacts.append(GenerationArtifact(filename=filename, content=content))
+
+
+class AdapterGenerator:
+    """Translate analysis results into actionable code generation plans."""
+
+    def build_plan(self, analysis: ChangeAnalysis) -> CodeGenerationPlan:
+        summary = self._summarize(analysis)
+        plan = CodeGenerationPlan(model=analysis.model, summary=summary)
+        for recommendation in analysis.recommended_updates:
+            plan.add_task(recommendation)
+        for schema_index, schema in enumerate(analysis.json_schemas, start=1):
+            filename = f"{analysis.model}_schema_{schema_index}.py"
+            content = self._render_schema_module(schema, analysis.model, schema_index)
+            plan.add_artifact(filename, content)
+        if not plan.tasks:
+            plan.add_task("Review documentation manually; no actionable items detected.")
+        return plan
+
+    def _summarize(self, analysis: ChangeAnalysis) -> str:
+        if analysis.insights_summary:
+            return analysis.insights_summary
+        if not analysis.signals:
+            return "No signals detected in documentation."
+        signals = ", ".join(signal.keyword for signal in analysis.signals)
+        return f"Signals detected for {analysis.model}: {signals}."
+
+    def _render_schema_module(self, schema: dict, model: str, index: int) -> str:
+        serialized_schema = json.dumps(schema, indent=4, sort_keys=True)
+        template = textwrap.dedent(
+            f'''"""Auto-generated schema snapshot for {model} (example {index})."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+EXAMPLE_SCHEMA = {serialized_schema}
+
+
+class ToolCallSchema(BaseModel):
+    """Pydantic model mirroring the scraped schema for regression tests."""
+
+    __root__: dict = EXAMPLE_SCHEMA
+'''
+        )
+        return template
+
+    def iter_artifact_paths(self, plan: CodeGenerationPlan) -> Iterable[str]:
+        for artifact in plan.artifacts:
+            yield artifact.filename

--- a/mcp_use/auto_update/intelligence.py
+++ b/mcp_use/auto_update/intelligence.py
@@ -1,0 +1,149 @@
+"""LLM-backed intelligence layer for documentation analysis."""
+
+from __future__ import annotations
+
+import json
+import re
+import textwrap
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from .scraper import DocumentationSnapshot
+
+
+@dataclass(slots=True)
+class IntelligenceSignal:
+    """A structured signal returned by the intelligence module."""
+
+    keyword: str
+    description: str
+    severity: str = "info"
+
+
+@dataclass(slots=True)
+class IntelligenceReport:
+    """Aggregated understanding of a documentation snapshot."""
+
+    summary: str
+    signals: list[IntelligenceSignal] = field(default_factory=list)
+    json_schemas: list[dict[str, Any]] = field(default_factory=list)
+    recommendations: list[str] = field(default_factory=list)
+
+
+class DocumentationIntelligence:
+    """Thin wrapper around an LLM that produces structured reports."""
+
+    PROMPT_TEMPLATE = textwrap.dedent(
+        """
+        You are an assistant that reviews MCP function-calling documentation. Given the text
+        below, analyse the entire content and respond ONLY with JSON using the following schema:
+        {
+          "summary": "string - high level synopsis of the changes",
+          "signals": [
+            {"keyword": "short token", "description": "string", "severity": "info|warning|breaking"}
+          ],
+          "json_schemas": [ {"type": "object", ... } ],
+          "recommendations": ["string", ...]
+        }
+        Ensure the payload is valid JSON and capture relevant schema examples verbatim.
+        Documentation text:
+        \"\"\"{documentation}\"\"\"
+        """
+    ).strip()
+
+    def __init__(self, llm: Callable[[str], str | dict[str, Any]] | None = None) -> None:
+        self._llm = llm
+
+    def analyze(self, snapshot: DocumentationSnapshot) -> IntelligenceReport:
+        if self._llm is None:
+            return self._heuristic_report(snapshot)
+        prompt = self.PROMPT_TEMPLATE.format(documentation=snapshot.raw_text)
+        raw_response = self._llm(prompt)
+        payload = self._coerce_payload(raw_response)
+        return self._report_from_payload(payload)
+
+    def _coerce_payload(self, raw_response: str | dict[str, Any]) -> dict[str, Any]:
+        if isinstance(raw_response, dict):
+            return raw_response
+        if not isinstance(raw_response, str):  # pragma: no cover - defensive programming
+            msg = "LLM response must be a string or dictionary"
+            raise TypeError(msg)
+        try:
+            return json.loads(raw_response)
+        except json.JSONDecodeError:
+            match = re.search(r"\{.*\}", raw_response, re.DOTALL)
+            if not match:
+                msg = "Unable to parse LLM output as JSON"
+                raise ValueError(msg) from None
+            return json.loads(match.group(0))
+
+    def _report_from_payload(self, payload: dict[str, Any]) -> IntelligenceReport:
+        summary = str(payload.get("summary", ""))
+        signals_payload = payload.get("signals", []) or []
+        signals = [
+            IntelligenceSignal(
+                keyword=str(item.get("keyword", "")),
+                description=str(item.get("description", "")),
+                severity=str(item.get("severity", "info")),
+            )
+            for item in signals_payload
+            if isinstance(item, dict)
+        ]
+        schemas_payload = payload.get("json_schemas", []) or []
+        json_schemas: list[dict[str, Any]] = []
+        for schema in schemas_payload:
+            if isinstance(schema, dict):
+                json_schemas.append(schema)
+        recommendations_payload = payload.get("recommendations", []) or []
+        recommendations = [
+            str(item) for item in recommendations_payload if isinstance(item, str)
+        ]
+        return IntelligenceReport(
+            summary=summary,
+            signals=signals,
+            json_schemas=json_schemas,
+            recommendations=recommendations,
+        )
+
+    def _heuristic_report(self, snapshot: DocumentationSnapshot) -> IntelligenceReport:
+        text_lower = snapshot.raw_text.lower()
+        signals: list[IntelligenceSignal] = []
+        keyword_mapping = {
+            "tool_choice": ("tool_choice keyword detected", "warning"),
+            "parallel_tool_calls": ("Parallel tool execution described", "breaking"),
+            "tool_use": ("Anthropic tool_use section detected", "warning"),
+            "function_call": ("Legacy function_call reference found", "info"),
+        }
+        for keyword, (description, severity) in keyword_mapping.items():
+            if keyword in text_lower:
+                signals.append(
+                    IntelligenceSignal(keyword=keyword, description=description, severity=severity)
+                )
+
+        json_schemas: list[dict[str, Any]] = []
+        for block in re.findall(r"```(?:json)?\s*(\{.*?\})\s*```", snapshot.raw_text, flags=re.DOTALL):
+            try:
+                parsed = json.loads(block)
+            except json.JSONDecodeError:  # pragma: no cover - defensive fallback
+                continue
+            if isinstance(parsed, dict):
+                json_schemas.append(parsed)
+
+        recommendations: list[str] = []
+        if any(signal.severity == "breaking" for signal in signals):
+            recommendations.append("Generate a high priority adapter patch and schedule integration tests.")
+        if any(signal.keyword == "tool_choice" for signal in signals):
+            recommendations.append("Update LangChainAdapter to map tool_choice fields to MCP call payloads.")
+        if json_schemas:
+            recommendations.append("Produce Pydantic models from discovered JSON schema examples for regression tests.")
+
+        summary = "No signals detected in documentation."
+        if signals:
+            summary = f"Signals detected for {snapshot.model}: " + ", ".join(signal.keyword for signal in signals)
+
+        return IntelligenceReport(
+            summary=summary,
+            signals=signals,
+            json_schemas=json_schemas,
+            recommendations=recommendations,
+        )

--- a/mcp_use/auto_update/scraper.py
+++ b/mcp_use/auto_update/scraper.py
@@ -1,0 +1,132 @@
+"""Utilities for collecting documentation about new tool calling formats."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from html import unescape
+from html.parser import HTMLParser
+from typing import Awaitable, Callable, Iterable
+
+import aiohttp
+
+
+@dataclass(slots=True)
+class DocumentationSnapshot:
+    """Represents a normalized version of scraped documentation."""
+
+    model: str
+    url: str
+    raw_text: str
+    retrieved_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    sections: dict[str, str] = field(default_factory=dict)
+
+    def get_section(self, name: str) -> str | None:
+        """Return a documentation section by its normalized name."""
+
+        key = name.lower().strip()
+        return self.sections.get(key)
+
+
+class _PlainTextExtractor(HTMLParser):
+    """Very small HTML to plain text converter."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._parts: list[str] = []
+
+    def handle_data(self, data: str) -> None:  # noqa: D401 - required override
+        if data:
+            self._parts.append(data)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:  # noqa: D401
+        if tag in {"p", "br", "div", "li", "h1", "h2", "h3"}:
+            self._parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:  # noqa: D401
+        if tag in {"p", "div", "li", "h1", "h2", "h3"}:
+            self._parts.append("\n")
+
+    def get_text(self) -> str:
+        return "".join(self._parts)
+
+
+class DocumentationScraper:
+    """Fetch and normalize documentation pages."""
+
+    def __init__(self, fetcher: Callable[[str], Awaitable[str]] | None = None) -> None:
+        self._fetcher = fetcher
+
+    async def scrape(self, model: str, url: str) -> DocumentationSnapshot:
+        """Scrape documentation for a given model and return a snapshot."""
+
+        raw = await self._fetch(url)
+        text = self._normalize_text(raw)
+        sections = self._split_sections(text)
+        return DocumentationSnapshot(model=model, url=url, raw_text=text, sections=sections)
+
+    def scrape_sync(self, model: str, url: str) -> DocumentationSnapshot:
+        """Synchronous wrapper for environments without an event loop."""
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            raise RuntimeError("scrape_sync cannot be called from a running event loop")
+
+        return asyncio.run(self.scrape(model, url))
+
+    async def _fetch(self, url: str) -> str:
+        if self._fetcher is not None:
+            return await self._fetcher(url)
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, timeout=aiohttp.ClientTimeout(total=30)) as response:
+                response.raise_for_status()
+                content_type = response.headers.get("Content-Type", "")
+                if "charset=" in content_type:
+                    return await response.text()
+                return await response.text(encoding="utf-8")
+
+    def _normalize_text(self, raw: str) -> str:
+        if "<" in raw and ">" in raw:
+            parser = _PlainTextExtractor()
+            parser.feed(raw)
+            text = parser.get_text()
+        else:
+            text = raw
+
+        text = unescape(text)
+        text = re.sub(r"\r\n|\r", "\n", text)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        text = re.sub(r"[ 	]{2,}", " ", text)
+        return text.strip()
+
+    def _split_sections(self, text: str) -> dict[str, str]:
+        headings = self._iter_headings(text)
+        sections: dict[str, str] = {}
+        for heading, content in headings:
+            sections[heading] = content.strip()
+        if not sections:
+            sections["body"] = text
+        return sections
+
+    def _iter_headings(self, text: str) -> Iterable[tuple[str, str]]:
+        pattern = re.compile(r"(?im)^(#{1,3}|[A-Z][A-Za-z0-9\s]{0,60})\n", re.MULTILINE)
+        matches = list(pattern.finditer(text))
+        if not matches:
+            return []
+        results: list[tuple[str, str]] = []
+        for index, match in enumerate(matches):
+            start = match.end()
+            end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+            heading = match.group(0).strip().lower().lstrip("# ")
+            content = text[start:end].strip()
+            if content:
+                results.append((heading, content))
+        return results
+

--- a/mcp_use/auto_update/tester.py
+++ b/mcp_use/auto_update/tester.py
@@ -1,0 +1,49 @@
+"""Offline validation helpers for generated adapters."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import Iterable
+
+from .generator import CodeGenerationPlan
+
+
+@dataclass(slots=True)
+class TestResult:
+    __test__ = False
+    """Represents the outcome of a validation step."""
+
+    name: str
+    passed: bool
+    details: str | None = None
+
+
+class AutoUpdateTestSuite:
+    """Run static checks over generation plans."""
+
+    def __init__(self, plan: CodeGenerationPlan) -> None:
+        self.plan = plan
+
+    def run(self) -> list[TestResult]:
+        results = [self._validate_tasks_present(), *self._validate_artifacts()]
+        return results
+
+    def _validate_tasks_present(self) -> TestResult:
+        if not self.plan.tasks:
+            return TestResult(name="tasks", passed=False, details="No tasks present in plan.")
+        return TestResult(name="tasks", passed=True)
+
+    def _validate_artifacts(self) -> Iterable[TestResult]:
+        for artifact in self.plan.artifacts:
+            try:
+                ast.parse(artifact.content)
+            except SyntaxError as exc:  # pragma: no cover - covered in error branch tests
+                yield TestResult(
+                    name=f"artifact:{artifact.filename}",
+                    passed=False,
+                    details=f"Generated artifact is not valid Python: {exc}",
+                )
+            else:
+                yield TestResult(name=f"artifact:{artifact.filename}", passed=True)
+

--- a/mcp_use/cli.py
+++ b/mcp_use/cli.py
@@ -4,12 +4,20 @@ MCP-Use CLI Tool - All-in-one CLI for creating and deploying MCP projects.
 """
 
 import argparse
+import asyncio
 import sys
 import threading
 import time
 from pathlib import Path
 
 from mcp_use import __version__
+from mcp_use.auto_update import (
+    AdapterGenerator,
+    AutoUpdateTestSuite,
+    DocumentationAnalyzer,
+    DocumentationIntelligence,
+    DocumentationScraper,
+)
 
 # ============= SPINNER CLASS =============
 
@@ -464,6 +472,9 @@ Available Commands:
   create     🚀 Create a new MCP project (server, agent, or both)
              Interactive wizard to scaffold your MCP project
 
+  auto-update 🔄  Plan adapter updates for a new model
+             Scrape docs, analyze changes, and generate tasks
+
   deploy     ☁️  Deploy your MCP project to the cloud
              (Coming soon - Cloud deployment from CLI)
 
@@ -477,6 +488,70 @@ For more information, visit: https://mcp-use.com
     """
     print(help_text)
 
+
+def handle_auto_update(argv: list[str]) -> None:
+    """Run the auto-update pipeline for a specific model."""
+
+    command_parser = argparse.ArgumentParser(
+        prog="mcp-use auto-update",
+        description="Scrape, analyze, and plan adapter updates for a model.",
+    )
+    command_parser.add_argument("--model", required=True, help="Model identifier, e.g. gpt-4.1")
+    command_parser.add_argument("--doc-url", required=True, help="URL to the function calling documentation")
+    command_parser.add_argument(
+        "--save-artifacts",
+        action="store_true",
+        help="Persist generated artifacts to disk instead of printing only",
+    )
+    command_parser.add_argument(
+        "--output-dir",
+        default="auto_update_artifacts",
+        help="Directory where artifacts are written when --save-artifacts is used",
+    )
+    options = command_parser.parse_args(argv)
+
+    print(f"\n🔎 Scraping documentation for {options.model}…")
+    scraper = DocumentationScraper()
+    try:
+        snapshot = asyncio.run(scraper.scrape(options.model, options.doc_url))
+    except Exception as exc:  # noqa: BLE001 - CLI surfaces generic failure message
+        print(f"\n❌ Failed to scrape documentation: {exc}")
+        sys.exit(1)
+
+    analyzer = DocumentationAnalyzer(intelligence=DocumentationIntelligence())
+    analysis = analyzer.analyze(snapshot)
+    generator = AdapterGenerator()
+    plan = generator.build_plan(analysis)
+
+    print("\n📌 Suggested tasks:")
+    for task in plan.tasks:
+        print(f"   - {task}")
+
+    if plan.artifacts:
+        print("\n🧪 Generated artifacts:")
+        for artifact in plan.artifacts:
+            print(f"   - {artifact.filename}")
+    else:
+        print("\nℹ️  No artifacts generated for this documentation snapshot.")
+
+    suite = AutoUpdateTestSuite(plan)
+    results = suite.run()
+    print("\n✅ Validation results:")
+    for result in results:
+        status = "PASS" if result.passed else "FAIL"
+        detail = f" ({result.details})" if result.details else ""
+        print(f"   - {result.name}: {status}{detail}")
+
+    if options.save_artifacts and plan.artifacts:
+        output_dir = Path(options.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        for artifact in plan.artifacts:
+            target = output_dir / artifact.filename
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(artifact.content)
+        print(f"\n💾 Saved artifacts to {output_dir.resolve()}")
+
+    print("\n✨ Auto-update planning complete.")
 
 def handle_create():
     """Handle the create command."""
@@ -556,10 +631,10 @@ def main(args=None):
     parser.add_argument("--help", "-h", action="store_true", help="Show help message")
 
     # Add subcommand as positional argument
-    parser.add_argument("command", nargs="?", choices=["create", "deploy"], help="Command to execute")
+    parser.add_argument("command", nargs="?", choices=["create", "deploy", "auto-update"], help="Command to execute")
 
     # Parse arguments
-    parsed_args = parser.parse_args(args)
+    parsed_args, remaining = parser.parse_known_args(args)
 
     # Handle help flag or no command
     if parsed_args.help or not parsed_args.command:
@@ -571,6 +646,8 @@ def main(args=None):
         handle_create()
     elif parsed_args.command == "deploy":
         handle_deploy()
+    elif parsed_args.command == "auto-update":
+        handle_auto_update(remaining)
     else:
         print(f"Unknown command: {parsed_args.command}")
         show_help()

--- a/tests/unit/auto_update/data/fake_model_doc.md
+++ b/tests/unit/auto_update/data/fake_model_doc.md
@@ -1,0 +1,38 @@
+Nebula Function Interface Draft
+
+Overview
+The experimental Nebula model introduces **invoke_directives** as the primary mechanism for
+selecting tool flows. Instead of classical tool identifiers, clients submit a directive slug
+that maps to a server-side binding. Parallel execution is described via the new
+**cooperative_branches** array.
+
+Invocation Flow
+1. Client issues a request with `invoke_directives` describing the desired binding.
+2. The assistant may branch into multiple invocations by listing contexts in `cooperative_branches`.
+3. Each branch includes a `telemetry_block` payload for auditing.
+
+JSON Schema
+```json
+{
+  "title": "Nebula Cooperative Call",
+  "type": "object",
+  "required": ["invoke_directives", "cooperative_branches"],
+  "properties": {
+    "invoke_directives": {"type": "array", "items": {"type": "string"}},
+    "cooperative_branches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "telemetry_block": {"type": "object", "properties": {"trace_id": {"type": "string"}}}
+        }
+      }
+    }
+  }
+}
+```
+
+Migration Notes
+- Update adapters to forward `invoke_directives` arrays without mapping to legacy tool identifiers.
+- Ensure generated code can reconcile multiple `cooperative_branches` and persist their telemetry.
+- Capture `telemetry_block` data for compliance pipelines.

--- a/tests/unit/auto_update/test_fake_documentation.py
+++ b/tests/unit/auto_update/test_fake_documentation.py
@@ -1,0 +1,84 @@
+import asyncio
+import json
+import re
+from pathlib import Path
+
+from mcp_use.auto_update.analyzer import DocumentationAnalyzer
+from mcp_use.auto_update.generator import AdapterGenerator
+from mcp_use.auto_update.intelligence import IntelligenceReport, IntelligenceSignal
+from mcp_use.auto_update.scraper import DocumentationScraper
+from mcp_use.auto_update.tester import AutoUpdateTestSuite
+
+
+class HeuristicIntelligence:
+    def analyze(self, snapshot):
+        text_lower = snapshot.raw_text.lower()
+        signals: list[IntelligenceSignal] = []
+        keyword_mapping = {
+            "tool_choice": ("tool_choice keyword detected", "warning"),
+            "parallel_tool_calls": ("parallel tool execution supported", "breaking"),
+        }
+        for keyword, (description, severity) in keyword_mapping.items():
+            if keyword in text_lower:
+                signals.append(IntelligenceSignal(keyword=keyword, description=description, severity=severity))
+
+        json_schemas: list[dict] = []
+        for block in re.findall(r"```json\s*(\{.*?\})\s*```", snapshot.raw_text, flags=re.DOTALL):
+            try:
+                parsed = json.loads(block)
+            except json.JSONDecodeError:  # pragma: no cover - defensive fallback
+                continue
+            if isinstance(parsed, dict):
+                json_schemas.append(parsed)
+
+        recommendations: list[str] = []
+        if any(signal.severity == "breaking" for signal in signals):
+            recommendations.append("Schedule integration tests for parallel tool execution")
+        if any(signal.keyword == "tool_choice" for signal in signals):
+            recommendations.append("Update LangChainAdapter to map tool_choice payloads")
+        if json_schemas:
+            recommendations.append("Generate schema artifacts from documentation examples")
+
+        summary = "No significant changes detected."
+        if signals:
+            summary = "Detected signals: " + ", ".join(signal.keyword for signal in signals)
+
+        return IntelligenceReport(
+            summary=summary,
+            signals=signals,
+            json_schemas=json_schemas,
+            recommendations=recommendations,
+        )
+
+
+def test_pipeline_handles_fake_documentation():
+    doc_path = Path(__file__).parent / "data" / "fake_model_doc.md"
+    fake_doc = doc_path.read_text()
+
+    async def fetcher(_url: str) -> str:
+        return fake_doc
+
+    scraper = DocumentationScraper(fetcher=fetcher)
+    snapshot = asyncio.run(scraper.scrape("gpt-fictitious", "file://fake"))
+
+    assert snapshot.model == "gpt-fictitious"
+    assert "invoke_directives" in snapshot.raw_text
+    assert "cooperative_branches" in snapshot.raw_text
+
+    analyzer = DocumentationAnalyzer(intelligence=HeuristicIntelligence())
+    analysis = analyzer.analyze(snapshot)
+
+    assert not analysis.signals, "The heuristic should not match unknown keywords"
+    assert analysis.json_schemas, "Expected JSON schemas to be extracted"
+
+    generator = AdapterGenerator()
+    plan = generator.build_plan(analysis)
+
+    assert plan.tasks, "The generation plan should include actionable tasks"
+    assert plan.artifacts, "The fake documentation should yield generated artifacts"
+    assert any("schema" in task.lower() for task in plan.tasks)
+
+    suite = AutoUpdateTestSuite(plan)
+    results = suite.run()
+
+    assert all(result.passed for result in results)

--- a/tests/unit/auto_update/test_pipeline.py
+++ b/tests/unit/auto_update/test_pipeline.py
@@ -1,0 +1,85 @@
+from mcp_use.auto_update.analyzer import DocumentationAnalyzer
+from mcp_use.auto_update.generator import AdapterGenerator
+from mcp_use.auto_update.intelligence import IntelligenceReport, IntelligenceSignal
+from mcp_use.auto_update.scraper import DocumentationSnapshot
+from mcp_use.auto_update.tester import AutoUpdateTestSuite, TestResult
+
+
+class FakeIntelligence:
+    def __init__(self, report: IntelligenceReport):
+        self.report = report
+        self.last_snapshot: DocumentationSnapshot | None = None
+
+    def analyze(self, snapshot: DocumentationSnapshot) -> IntelligenceReport:
+        self.last_snapshot = snapshot
+        return self.report
+
+
+def build_analyzer(report: IntelligenceReport) -> DocumentationAnalyzer:
+    return DocumentationAnalyzer(intelligence=FakeIntelligence(report))
+
+
+def build_snapshot(text: str) -> DocumentationSnapshot:
+    return DocumentationSnapshot(model="gpt-x", url="https://example.com", raw_text=text, sections={})
+
+
+def test_analyzer_detects_signals_and_json():
+    text = """
+    The new interface introduces tool_choice and parallel_tool_calls.
+
+    ```json
+    {"type": "object", "properties": {"tool_calls": {"type": "array"}}}
+    ```
+    """
+    report = IntelligenceReport(
+        summary="Parallel tools and schema updates detected.",
+        signals=[
+            IntelligenceSignal(keyword="tool_choice", description="tool_choice keyword introduced", severity="warning"),
+            IntelligenceSignal(keyword="parallel_tool_calls", description="Parallel execution supported", severity="breaking"),
+        ],
+        json_schemas=[{"type": "object", "properties": {"tool_calls": {"type": "array"}}}],
+        recommendations=[
+            "Update LangChainAdapter to support tool_choice",
+            "Add regression schema",
+        ],
+    )
+
+    analyzer = build_analyzer(report)
+    analysis = analyzer.analyze(build_snapshot(text))
+
+    assert {signal.keyword for signal in analysis.signals} >= {"tool_choice", "parallel_tool_calls"}
+    assert analysis.json_schemas, "Expected JSON schemas to be captured"
+    assert any("LangChainAdapter" in rec for rec in analysis.recommended_updates)
+
+
+def test_generator_and_testsuite_validate_plan():
+    text = """
+    tool_choice is now required.
+
+    ```json
+    {"required": ["tool_choice"]}
+    ```
+    """
+    report = IntelligenceReport(
+        summary="tool_choice now required.",
+        signals=[
+            IntelligenceSignal(keyword="tool_choice", description="tool_choice is required", severity="warning"),
+        ],
+        json_schemas=[{"required": ["tool_choice"]}],
+        recommendations=["Update LangChainAdapter mapping", "Generate schema artifact"],
+    )
+
+    analyzer = build_analyzer(report)
+    analysis = analyzer.analyze(build_snapshot(text))
+
+    generator = AdapterGenerator()
+    plan = generator.build_plan(analysis)
+
+    assert plan.tasks, "Generator should include at least one task"
+    assert plan.artifacts, "JSON schema should produce artifacts"
+
+    suite = AutoUpdateTestSuite(plan)
+    results = suite.run()
+
+    assert all(result.passed for result in results)
+    assert isinstance(results[0], TestResult)

--- a/tests/unit/auto_update/test_scraper.py
+++ b/tests/unit/auto_update/test_scraper.py
@@ -1,0 +1,24 @@
+import asyncio
+import pytest
+
+from mcp_use.auto_update.scraper import DocumentationScraper
+
+
+def test_scraper_normalizes_html_headings():
+    async def fake_fetch(url: str) -> str:  # noqa: ARG001 - fixture style helper
+        return """
+        <html>
+            <body>
+                <h1>Tool Choice</h1>
+                <p>Use the <code>tool_choice</code> field to control function calling.</p>
+            </body>
+        </html>
+        """
+
+    scraper = DocumentationScraper(fetcher=fake_fetch)
+    snapshot = asyncio.run(scraper.scrape("gpt-x", "https://example.com"))
+
+    assert snapshot.model == "gpt-x"
+    assert snapshot.get_section("tool choice")
+    assert "tool_choice" in snapshot.raw_text
+    assert "Use the" in snapshot.raw_text


### PR DESCRIPTION
## Summary
- update the synthetic documentation fixture to describe Nebula-specific signals that do not match existing heuristics
- adjust the fake documentation pipeline test to confirm the analyzer tolerates unknown keywords while still producing schema-driven tasks
- clean up the generator module header so future-imports remain valid during test collection

## Testing
- `pytest tests/unit/auto_update/test_scraper.py tests/unit/auto_update/test_pipeline.py tests/unit/auto_update/test_fake_documentation.py`


------
https://chatgpt.com/codex/tasks/task_e_68d3cf4bd4f08323a3ff8915d3e10334